### PR TITLE
Pin bazel to less than 3.7 on Windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
     - patches/0013-permit-python-3.9.patch
 
 build:
-  number: 1
+  number: 2
   skip: True  # [py<36]
   # skip on MacOS as there's some weird compilation issue and I have no MacOS to develop on
   skip: True  # [osx]
@@ -35,7 +35,7 @@ requirements:
     - {{ compiler('cxx') }}
     - cython >=0.29
     - bazel <=3.4.1  # [not win]
-    - bazel  # [win]
+    - bazel <3.7  # [win]
     - curl
     - make
     - m2-patch  # [win]
@@ -68,7 +68,7 @@ outputs:
         - {{ compiler('cxx') }}
         - cython >=0.29
         - bazel <=3.4.1  # [not win]
-        - bazel  # [win]
+        - bazel <3.7  # [win]
         - curl
         - make
       host:


### PR DESCRIPTION
This is an attempt to fix Windows builds which _seem_ to be broken by new Bazel coming out (previous builds used 3.x, Ray itself wants 3.4 or something similar, and recently published Bazel is 4.0).

I'm trying to pin Bazel to the least version which has Windows bits on conda-forge (it should be the version used in initial publishings).