### PR TITLE
add init-test to ray-core, bring back opencensus

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: linux
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
   strategy:
     matrix:
       linux_64_python3.6.____cpython:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -99,6 +99,7 @@ outputs:
         - jsonschema
         - msgpack-python >=1.0.0, <2.0.0
         - numpy >=1.16
+        - opencensus
         - pickle5  # [py<38]
         - prometheus_client >=0.7.1
         - protobuf >=3.8.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ source:
     - patches/0015-Ignore-warnings-in-logging.cc.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<36]
   # skip on MacOS as there's some weird compilation issue and I have no MacOS to develop on
   skip: true  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -116,6 +116,8 @@ outputs:
         - ray.runtime_context
         - ray.state
         - ray.worker
+      commands:
+        - python -c "import ray; ray.init()"
 
   - name: ray-autoscaler
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -118,6 +118,10 @@ outputs:
         - ray.worker
       commands:
         - python -c "import ray; ray.init()"
+        # init-code seemingly depends on platform or other ambient things;
+        # the following doesn't get triggered in CI, but was a problem in
+        # https://github.com/conda-forge/ray-packages-feedstock/issues/16
+        - python -c "import ray.metrics_agent"
 
   - name: ray-autoscaler
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -117,12 +117,12 @@ outputs:
         - ray.runtime_context
         - ray.state
         - ray.worker
-      commands:
-        - python -c "import ray; ray.init()"
         # init-code seemingly depends on platform or other ambient things;
         # the following doesn't get triggered in CI, but was a problem in
         # https://github.com/conda-forge/ray-packages-feedstock/issues/16
-        - python -c "import ray.metrics_agent"
+        - ray.metrics_agent
+      commands:
+        - python -c "import ray; ray.init()"
 
   - name: ray-autoscaler
     build:


### PR DESCRIPTION
Add more tests, re-introduce `opencensus` as a requirement for `ray-core`.

Closes #16.