### PR TITLE
Move jsonschema dependency to ray-core

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 
 build:
-  number: 1
+  number: 2
   # skip on MacOS as there's some weird compilation issue and I have no MacOS to develop on
   skip: true  # [osx]
 
@@ -82,6 +82,7 @@ outputs:
         - filelock
         - frozenlist
         - grpcio >=1.28.1, <=1.43.0
+        - jsonschema
         - msgpack-python >=1.0.0, <2.0.0
         - numpy >=1.20
         - pickle5  # [py<38]
@@ -118,7 +119,6 @@ outputs:
         # gpustat-0.6.0 has a dependency which does not exist on Windows;
         # skip it there until gpustat is fixed as it is optional
         - gpustat  # [not win]
-        - jsonschema
         - opencensus
         - prometheus_client >=0.7.1, <0.14.0
         - requests


### PR DESCRIPTION
The jsonschema dependency is part of ray-core upstream, so this should be reflected here, too.

Signed-off-by: Kai Fricke <kai@anyscale.com>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
