### PR TITLE
Cleanup dependency cruft

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,12 +25,6 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - bazel =4.2.2
-    - cython >=0.29.26
-    - curl
-    - make
-    - m2-patch       # [win]
-    - python
 
 outputs:
   - name: ray-all

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,9 +63,6 @@ outputs:
         - python
         - pip
         - packaging
-        # pickle5 needs to be here, otherwise setup.py tries
-        # to install it and it fails on conda-forge Windows CI
-        - pickle5  # [py<38]
         - openjdk =11
       run:
         - python
@@ -73,7 +70,6 @@ outputs:
         - attrs
         - click >=7.0, <=8.0.4
         - colorama
-        - dataclasses  # [py<37]
         - filelock
         - frozenlist
         # We override the 1.43.0 upper-bound in setup.py here,
@@ -82,14 +78,12 @@ outputs:
         - jsonschema
         - msgpack-python >=1.0.0, <2.0.0
         - numpy >=1.20
-        - pickle5  # [py<38]
         - protobuf >=3.15.3, <4.0.0
         - psutil
         - pyyaml
         - redis-py >=3.5.0  # [win]
         - requests
         - setproctitle =1.2.2
-        - typing_extensions  # [py<38]
         - virtualenv
 
     test:
@@ -178,10 +172,8 @@ outputs:
       run:
         - python
         - {{ pin_subpackage('ray-core', exact=True) }}
-        - numpy >=1.19  # [py<37]
-        - numpy >=1.20  # [py>=37]
-        - pandas >=1.0.5  # [py<37]
-        - pandas >=1.3  # [py>=37]
+        - numpy >=1.20
+        - pandas >=1.3
         - pyarrow >=6.0.1, <7.0.0
         - fsspec
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 
 build:
-  number: 0
+  number: 1
   # skip on MacOS, needs macos 10.15
   skip: true  # [osx]
 
@@ -81,7 +81,6 @@ outputs:
         - protobuf >=3.15.3, <4.0.0
         - psutil
         - pyyaml
-        - redis-py >=3.5.0  # [win]
         - requests
         - setproctitle =1.2.2
         - virtualenv
@@ -106,7 +105,6 @@ outputs:
         - {{ pin_subpackage('ray-core', exact=True) }}
         - aiohttp >=3.7
         - aiohttp-cors
-        - aioredis <2
         - colorful
         - gpustat
         - opencensus
@@ -194,9 +192,6 @@ outputs:
         - gym >=0.21.0, <0.24
         - lz4
         - matplotlib-base !=3.4.3
-        # scikit-image uses a deprecated import for pooch, causing rllib to fail on import
-        # pinning pooch to <1.5 solves this issue for now
-        - pooch <1.5
         - pyyaml
         - scikit-image
         - scipy


### PR DESCRIPTION
A few things from #80 that had been languishing for a while.

aioredis & redis-py got removed upstream even before 1.13.