### PR TITLE
lift upper pin on grpc

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - patches/0004-Remove-all-dependencies-from-setup.py.patch
 
 build:
-  number: 0
+  number: 1
 
 # Need these up here for conda-smithy to handle them properly.
 requirements:
@@ -169,7 +169,7 @@ outputs:
         - aiohttp-cors
         - colorful
         - gpustat >=1.0.0
-        - grpcio >=1.50,<1.56
+        - grpcio >=1.50
         - opencensus
         - prometheus_client >=0.7.1
         - pydantic <2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -169,7 +169,7 @@ outputs:
         - aiohttp-cors
         - colorful
         - gpustat >=1.0.0
-        - grpcio >=1.50
+        - grpcio >=1.50,<1.59
         - opencensus
         - prometheus_client >=0.7.1
         - pydantic <2.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->


Currently, ray 2.8 won't work with a variety of important packages due to the grpc pin. However, ray seems to also not work great with the latest grpc, so I've trial/errored down to the latest compatible pin. 