### PR TITLE
Patch vendored grpc to 1.59.3 and export a dependency in ray-core

### DIFF
--- a/.ci_support/linux_64_python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_python3.10.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libgrpc:
+- '1.59'
 nodejs:
 - '18'
 - '20'

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libgrpc:
+- '1.59'
 nodejs:
 - '18'
 - '20'

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libgrpc:
+- '1.59'
 nodejs:
 - '18'
 - '20'

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler_version:
 - '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+libgrpc:
+- '1.59'
 nodejs:
 - '18'
 - '20'

--- a/.ci_support/migrations/libgrpc159_libprotobuf4244.yaml
+++ b/.ci_support/migrations/libgrpc159_libprotobuf4244.yaml
@@ -1,0 +1,16 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+  exclude:
+    # this shouldn't attempt to modify the python feedstocks
+    - protobuf
+libgrpc:
+- "1.59"
+libprotobuf:
+- 4.24.4
+# already covered by libabseil20230802_libgrpc157_libprotobuf4234,
+# which we cannot delete yet, but keep for clarity
+MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
+- "10.13"                  # [osx and x86_64]
+migrator_ts: 1698833751.21557

--- a/.ci_support/osx_64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_python3.10.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '16'
+libgrpc:
+- '1.59'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 nodejs:

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '16'
+libgrpc:
+- '1.59'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 nodejs:

--- a/.ci_support/osx_64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '16'
+libgrpc:
+- '1.59'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 nodejs:

--- a/.ci_support/osx_64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_python3.9.____cpython.yaml
@@ -16,6 +16,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '16'
+libgrpc:
+- '1.59'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 nodejs:

--- a/.ci_support/osx_arm64_python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.10.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '16'
+libgrpc:
+- '1.59'
 macos_machine:
 - arm64-apple-darwin20.0.0
 nodejs:

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '16'
+libgrpc:
+- '1.59'
 macos_machine:
 - arm64-apple-darwin20.0.0
 nodejs:

--- a/.ci_support/osx_arm64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.8.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '16'
+libgrpc:
+- '1.59'
 macos_machine:
 - arm64-apple-darwin20.0.0
 nodejs:

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -14,6 +14,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '16'
+libgrpc:
+- '1.59'
 macos_machine:
 - arm64-apple-darwin20.0.0
 nodejs:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,10 @@ source:
     - patches/0003-Ignore-warnings-in-event.cc-and-logging.cc.patch
     - patches/0004-Remove-all-dependencies-from-setup.py.patch
     - patches/0005-ci-remove-boost-as-a-dependency-42226.patch
+    - patches/0006-Vendor-grpc-1.59.3.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 # Need these up here for conda-smithy to handle them properly.
@@ -71,6 +72,7 @@ outputs:
         - python
         - pip
         - packaging
+        - libgrpc
         - openjdk =11
       run:
         - python
@@ -179,12 +181,15 @@ outputs:
       run:
         - python
         - {{ pin_subpackage('ray-core', exact=True) }}
-        - grpcio !=1.56.0  # [osx]
-        - grpcio  # [not osx]
+        - grpcio
     test:
       imports:
         # there doesn't appear to be a client module, not sure how to test this
         - ray
+      commands:
+        - ray start --head
+        - python -c "import ray; ray.init('ray://127.0.0.1:10001')"
+        - ray stop
 
   - name: ray-rllib
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -184,7 +184,6 @@ outputs:
         - grpcio
     test:
       imports:
-        # there doesn't appear to be a client module, not sure how to test this
         - ray
       commands:
         - ray start --head

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,9 @@ source:
     - patches/0006-Vendor-grpc-1.59.3.patch
     # This patch applies grpc tag v1.59.3 changes from
     # https://github.com/grpc/grpc/blob/35df344f5e17a9cb290ebf0f5b0f03ddb1ff0a97/bazel/grpc_deps.bzl#L243
+    - patches/0007-ci-upgrade-ray-openssl.patch
+    # xref https://github.com/ray-project/ray/pull/42557
+    # xref https://github.com/ray-project/ray/issues/42560
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - patches/0006-Vendor-grpc-1.59.3.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
 
 # Need these up here for conda-smithy to handle them properly.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,8 @@ source:
     - patches/0004-Remove-all-dependencies-from-setup.py.patch
     - patches/0005-ci-remove-boost-as-a-dependency-42226.patch
     - patches/0006-Vendor-grpc-1.59.3.patch
+    # This patch applies grpc tag v1.59.3 changes from
+    # https://github.com/grpc/grpc/blob/35df344f5e17a9cb290ebf0f5b0f03ddb1ff0a97/bazel/grpc_deps.bzl#L243
 
 build:
   number: 2

--- a/recipe/patches/0006-Vendor-grpc-1.59.3.patch
+++ b/recipe/patches/0006-Vendor-grpc-1.59.3.patch
@@ -20,7 +20,7 @@ index c406ba9281..ae7ee4540a 100644
 +        sha256 = "660ce016f987550bc1ccec4a6ee4199afb871799b696227098e3641476a7d566",
 +        strip_prefix = "protobuf-b2b7a51158418f41cff0520894836c15b1738721",
          urls = [
-             # https://github.com/protocolbuffers/protobuf/commits/v23.4
+-            # https://github.com/protocolbuffers/protobuf/commits/v23.4
 -            "https://github.com/protocolbuffers/protobuf/archive/2c5fa078d8e86e5f4bd34e6f4c9ea9e8d7d4d44a.tar.gz",
 +            "https://github.com/protocolbuffers/protobuf/archive/b2b7a51158418f41cff0520894836c15b1738721.tar.gz",
          ],

--- a/recipe/patches/0006-Vendor-grpc-1.59.3.patch
+++ b/recipe/patches/0006-Vendor-grpc-1.59.3.patch
@@ -3,8 +3,6 @@ From: Austin Morton <austin.morton@aquatic.com>
 Date: Fri, 19 Jan 2024 20:11:02 +0000
 Subject: [PATCH] Vendor grpc 1.59.3
 
-# This patch applies grpc tag v1.59.3 changes from
-# https://github.com/grpc/grpc/blob/35df344f5e17a9cb290ebf0f5b0f03ddb1ff0a97/bazel/grpc_deps.bzl#L243
 ---
  bazel/ray_deps_setup.bzl | 19 +++++++++----------
  1 file changed, 9 insertions(+), 10 deletions(-)

--- a/recipe/patches/0006-Vendor-grpc-1.59.3.patch
+++ b/recipe/patches/0006-Vendor-grpc-1.59.3.patch
@@ -3,8 +3,8 @@ From: Austin Morton <austin.morton@aquatic.com>
 Date: Fri, 19 Jan 2024 20:11:02 +0000
 Subject: [PATCH] Vendor grpc 1.59.3
 
-This patch applies grpc tag v1.59.3 changes from
-https://github.com/grpc/grpc/blob/35df344f5e17a9cb290ebf0f5b0f03ddb1ff0a97/bazel/grpc_deps.bzl#L243
+# This patch applies grpc tag v1.59.3 changes from
+# https://github.com/grpc/grpc/blob/35df344f5e17a9cb290ebf0f5b0f03ddb1ff0a97/bazel/grpc_deps.bzl#L243
 ---
  bazel/ray_deps_setup.bzl | 19 +++++++++----------
  1 file changed, 9 insertions(+), 10 deletions(-)

--- a/recipe/patches/0006-Vendor-grpc-1.59.3.patch
+++ b/recipe/patches/0006-Vendor-grpc-1.59.3.patch
@@ -1,0 +1,60 @@
+From 744d936f573f55e6c8568b19b6ecd6ed891abc31 Mon Sep 17 00:00:00 2001
+From: Austin Morton <austin.morton@aquatic.com>
+Date: Fri, 19 Jan 2024 20:11:02 +0000
+Subject: [PATCH] Vendor grpc 1.59.3
+
+---
+ bazel/ray_deps_setup.bzl | 19 +++++++++----------
+ 1 file changed, 9 insertions(+), 10 deletions(-)
+
+diff --git a/bazel/ray_deps_setup.bzl b/bazel/ray_deps_setup.bzl
+index c406ba9281..ae7ee4540a 100644
+--- a/bazel/ray_deps_setup.bzl
++++ b/bazel/ray_deps_setup.bzl
+@@ -89,11 +89,10 @@ def ray_deps_setup():
+     # This is copied from grpc's bazel/grpc_deps.bzl
+     http_archive(
+         name = "com_google_protobuf",
+-        sha256 = "76a33e2136f23971ce46c72fd697cd94dc9f73d56ab23b753c3e16854c90ddfd",
+-        strip_prefix = "protobuf-2c5fa078d8e86e5f4bd34e6f4c9ea9e8d7d4d44a",
++        sha256 = "660ce016f987550bc1ccec4a6ee4199afb871799b696227098e3641476a7d566",
++        strip_prefix = "protobuf-b2b7a51158418f41cff0520894836c15b1738721",
+         urls = [
+-            # https://github.com/protocolbuffers/protobuf/commits/v23.4
+-            "https://github.com/protocolbuffers/protobuf/archive/2c5fa078d8e86e5f4bd34e6f4c9ea9e8d7d4d44a.tar.gz",
++            "https://github.com/protocolbuffers/protobuf/archive/b2b7a51158418f41cff0520894836c15b1738721.tar.gz",
+         ],
+         patches = [
+             "@com_github_grpc_grpc//third_party:protobuf.patch",
+@@ -243,8 +242,8 @@ def ray_deps_setup():
+     auto_http_archive(
+         name = "com_github_grpc_grpc",
+         # NOTE: If you update this, also update @boringssl's hash.
+-        url = "https://github.com/grpc/grpc/archive/refs/tags/v1.57.1.tar.gz",
+-        sha256 = "0762f809b9de845e6a7c809cabccad6aa4143479fd43b396611fe5a086c0aeeb",
++        url = "https://github.com/grpc/grpc/archive/refs/tags/v1.59.3.tar.gz",
++        sha256 = "ea281bb3489520ad4fb96ae84b45ed194a1f0b944d3e74f925f5e019d31ecd0f",
+         patches = [
+             "@com_github_ray_project_ray//thirdparty/patches:grpc-cython-copts.patch",
+         ],
+@@ -286,13 +285,13 @@ def ray_deps_setup():
+     http_archive(
+         # This rule is used by @com_github_grpc_grpc, and using a GitHub mirror
+         # provides a deterministic archive hash for caching. Explanation here:
+-        # https://github.com/grpc/grpc/blob/1ff1feaa83e071d87c07827b0a317ffac673794f/bazel/grpc_deps.bzl#L189
++        # https://github.com/grpc/grpc/blob/v1.59.3/bazel/grpc_deps.bzl#L219
+         # Ensure this rule matches the rule used by grpc's bazel/grpc_deps.bzl
+         name = "boringssl",
+-        sha256 = "0675a4f86ce5e959703425d6f9063eaadf6b61b7f3399e77a154c0e85bad46b1",
+-        strip_prefix = "boringssl-342e805bc1f5dfdd650e3f031686d6c939b095d9",
++        sha256 = "b21994a857a7aa6d5256ffe355c735ad4c286de44c6c81dfc04edc41a8feaeef",
++        strip_prefix = "boringssl-2ff4b968a7e0cfee66d9f151cb95635b43dc1d5b",
+         urls = [
+-            "https://github.com/google/boringssl/archive/342e805bc1f5dfdd650e3f031686d6c939b095d9.tar.gz",
++            "https://github.com/google/boringssl/archive/2ff4b968a7e0cfee66d9f151cb95635b43dc1d5b.tar.gz",
+         ],
+     )
+ 
+-- 
+2.42.0
+

--- a/recipe/patches/0006-Vendor-grpc-1.59.3.patch
+++ b/recipe/patches/0006-Vendor-grpc-1.59.3.patch
@@ -3,6 +3,8 @@ From: Austin Morton <austin.morton@aquatic.com>
 Date: Fri, 19 Jan 2024 20:11:02 +0000
 Subject: [PATCH] Vendor grpc 1.59.3
 
+This patch applies grpc tag v1.59.3 changes from
+https://github.com/grpc/grpc/blob/35df344f5e17a9cb290ebf0f5b0f03ddb1ff0a97/bazel/grpc_deps.bzl#L243
 ---
  bazel/ray_deps_setup.bzl | 19 +++++++++----------
  1 file changed, 9 insertions(+), 10 deletions(-)
@@ -20,7 +22,7 @@ index c406ba9281..ae7ee4540a 100644
 +        sha256 = "660ce016f987550bc1ccec4a6ee4199afb871799b696227098e3641476a7d566",
 +        strip_prefix = "protobuf-b2b7a51158418f41cff0520894836c15b1738721",
          urls = [
--            # https://github.com/protocolbuffers/protobuf/commits/v23.4
+             # https://github.com/protocolbuffers/protobuf/commits/v23.4
 -            "https://github.com/protocolbuffers/protobuf/archive/2c5fa078d8e86e5f4bd34e6f4c9ea9e8d7d4d44a.tar.gz",
 +            "https://github.com/protocolbuffers/protobuf/archive/b2b7a51158418f41cff0520894836c15b1738721.tar.gz",
          ],

--- a/recipe/patches/0007-ci-upgrade-ray-openssl.patch
+++ b/recipe/patches/0007-ci-upgrade-ray-openssl.patch
@@ -1,0 +1,29 @@
+From 9abb2df780560e233b7831f52dab1bdeacb72fb9 Mon Sep 17 00:00:00 2001
+From: can <can@anyscale.com>
+Date: Sun, 21 Jan 2024 05:03:48 +0000
+Subject: [PATCH] [ci] upgrade ray openssl
+
+---
+ bazel/ray_deps_setup.bzl | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/bazel/ray_deps_setup.bzl b/bazel/ray_deps_setup.bzl
+index f91eb303c4..3411c4873c 100644
+--- a/bazel/ray_deps_setup.bzl
++++ b/bazel/ray_deps_setup.bzl
+@@ -243,10 +243,10 @@ def ray_deps_setup():
+
+     http_archive(
+         name = "openssl",
+-        strip_prefix = "openssl-1.1.1f",
+-        sha256 = "186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35",
++        strip_prefix = "openssl-1.1.1w",
++        sha256 = "cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8",
+         urls = [
+-            "https://www.openssl.org/source/openssl-1.1.1f.tar.gz",
++            "https://www.openssl.org/source/openssl-1.1.1w.tar.gz",
+         ],
+         build_file = "@rules_foreign_cc_thirdparty//openssl:BUILD.openssl.bazel",
+     )
+--
+2.43.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

See discussion in #90, #136, and #139

~Note:  I built this locally without the 1.59 migration to check if this approach works with grpc 1.58 and `python -c "import ray; ray.init('ray://127.0.0.1:10001')"` still hangs, so there is still an unknown issue at play here.~ I tested this incorrectly, re-running locally again on 1.58.