### PR TITLE
remove ray-llm that depends on vllm, which is not available on conda-forge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 
 # Rattler-build's artifacts are in `output` when not specifying anything.
 /output
+# Pixi's configuration
+.pixi

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Documentation: https://ray.readthedocs.io/
 Ray is a fast and simple framework for building and running
 distributed applications. It is split into ray-core, ray-default,
 ray-serve, ray-rllib, ray-client, ray-data, ray-tune,
-ray-train, ray-observability, ray-adag, ray-cgraph and
+ray-train, ray-observability, ray-adag, ray-cgraph, ray-llm and
 ray-all packages.
 
 

--- a/recipe/build-core.bat
+++ b/recipe/build-core.bat
@@ -33,6 +33,7 @@ echo ==========================================================
 cd python
 echo startup --output_user_root=D:/tmp >> ..\.bazelrc
 echo build --jobs=1 >> ..\.bazelrc
+echo build --subcommands=pretty_print >> ..\.bazelrc
 "%PYTHON%" -m pip install . -vv
 
 rem remember the return code

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ source:
     - patches/0011-patch-bundled-fmt-in-spdlog-for-invalid-char8_type.patch
 
 build:
-  number: 0
+  number: 2
 
 # Need these up here for conda-smithy to handle them properly.
 requirements:
@@ -319,20 +319,6 @@ outputs:
     test:
       commands:
         - echo "no tests for ray-cgraph, it is a convenience bundle"
-
-  - name: ray-llm
-    requirements:
-      host:
-        - python
-      run:
-        - python
-        - {{ pin_subpackage('ray-data', exact=True) }}
-        - {{ pin_subpackage('ray-serve', exact=True) }}
-        - async_timeout
-        - asyncache >=0.3.1
-        - boto3
-        - jsonref >=1.1.0
-        - vllm >=0.7.2
 
 about:
   home: https://github.com/ray-project/ray

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -218,7 +218,7 @@ outputs:
         - dm-tree
         - gymnasium ==1.0.0
         - lz4
-        - ormsgpack==1.7.0
+        - ormsgpack ==1.7.0
         - pyyaml
         - scipy
     test:


### PR DESCRIPTION


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
