### PR TITLE
Don't export the protobuf symbol (_upb_Arena_SlowMalloc_dont_copy_me__upb_internal_use_only)

### DIFF
--- a/recipe/patches/0009-fix-symbols.patch
+++ b/recipe/patches/0009-fix-symbols.patch
@@ -1,0 +1,40 @@
+From 215340c82cc6ca40874987b3d5b24df16b1870a1 Mon Sep 17 00:00:00 2001
+From: Rueian Huang <rueian@gmail.com>
+Date: Thu, 19 Feb 2026 16:21:07 -0800
+Subject: [PATCH] [core] fix symbols
+
+Signed-off-by: Rueian Huang <rueian@gmail.com>
+---
+ src/ray/ray_exported_symbols.lds | 2 +-
+ src/ray/ray_version_script.lds   | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/ray/ray_exported_symbols.lds b/src/ray/ray_exported_symbols.lds
+index 9d57bf03a6fe..cb5b83e8b4f2 100644
+--- a/src/ray/ray_exported_symbols.lds
++++ b/src/ray/ray_exported_symbols.lds
+@@ -29,7 +29,7 @@
+ *ray*gcs*
+ *ray*CoreWorker*
+ *ray*PeriodicalRunner*
+-*ray*internal*
++*ray8internal*
+ *PyInit__raylet*
+ *Java_io_ray*
+ _JNI_On*
+diff --git a/src/ray/ray_version_script.lds b/src/ray/ray_version_script.lds
+index eb6d54063e04..d485d7ac5a35 100644
+--- a/src/ray/ray_version_script.lds
++++ b/src/ray/ray_version_script.lds
+@@ -31,7 +31,7 @@ VERSION_1.0 {
+ *ray*stats*;
+ *ray*CoreWorker*;
+ *ray*PeriodicalRunner*;
+- *ray*internal*;
++ *ray8internal*;
+ *PyInit*;
+ *init_raylet*;
+ *Java*;
+-- 
+2.48.0
+

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -25,9 +25,10 @@ source:
     - patches/0007-patch-zlib-in-prometheus-cpp-and-boost.patch
     # Turns off --incompatible_strict_action_env
     - patches/0008-bazel-disable-strict-env.patch
+    - patches/0009-fix-symbols.patch
 
 build:
-  number: 0
+  number: 1
   skip:
     - match(python, "<3.11")
 


### PR DESCRIPTION
Ray's `_raylet.so` accidentally exposes the protobuf `_upb_Arena_SlowMalloc_dont_copy_me__upb_internal_use_only` symbol and causes protobuf to fail in the ray client server. This patch makes the symbol not exposed.

Ref: https://github.com/ray-project/ray/pull/61147

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
