### PR TITLE
ray-packages v2.54.1

### DIFF
--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- self-hosted@cirun-openstack-cpu-4xlarge
 libgrpc:
 - '1.73'
 pin_run_as_build:

--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- self-hosted@cirun-openstack-cpu-4xlarge
+- ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg
 libgrpc:
 - '1.73'
 pin_run_as_build:

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- self-hosted@cirun-openstack-cpu-4xlarge
 libgrpc:
 - '1.73'
 pin_run_as_build:

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- self-hosted@cirun-openstack-cpu-4xlarge
+- ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg
 libgrpc:
 - '1.73'
 pin_run_as_build:

--- a/.ci_support/linux_64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_python3.13.____cp313.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- cirun-openstack-cpu-4xlarge
+- self-hosted@cirun-openstack-cpu-4xlarge
 libgrpc:
 - '1.73'
 pin_run_as_build:

--- a/.ci_support/linux_64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_python3.13.____cp313.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 github_actions_labels:
-- self-hosted@cirun-openstack-cpu-4xlarge
+- ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg
 libgrpc:
 - '1.73'
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.15'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.15'
+- '11.0'
 c_compiler:
 - clang
 c_compiler_version:
@@ -9,7 +9,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.15'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_python3.12.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.15'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.15'
+- '11.0'
 c_compiler:
 - clang
 c_compiler_version:
@@ -9,7 +9,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.15'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_python3.13.____cp313.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.15'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '10.15'
+- '11.0'
 c_compiler:
 - clang
 c_compiler_version:
@@ -9,7 +9,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.15'
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -19,22 +19,23 @@ jobs:
     timeout-minutes: 360
     strategy:
       fail-fast: false
+      max-parallel: 50
       matrix:
         include:
           - CONFIG: linux_64_python3.11.____cpython
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_python3.11.____cpython', 'linux', 'x64', 'self-hosted']
+            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_python3.11.____cpython']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_python3.12.____cpython
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_python3.12.____cpython', 'linux', 'x64', 'self-hosted']
+            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_python3.12.____cpython']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_python3.13.____cp313
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_python3.13.____cp313', 'linux', 'x64', 'self-hosted']
+            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_python3.13.____cp313']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
     steps:
 
@@ -109,7 +110,7 @@ jobs:
         # default value; make it explicit, as it needs to match with artefact
         # generation below. Not configurable for now, can be revisited later
         CONDA_BLD_DIR: C:\bld
-        MINIFORGE_HOME: D:\Miniforge
+        MINIFORGE_HOME: ${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}:\Miniforge
         PYTHONUNBUFFERED: 1
         CONFIG: ${{ matrix.CONFIG }}
         CI: github_actions

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -25,17 +25,17 @@ jobs:
           - CONFIG: linux_64_python3.11.____cpython
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_python3.11.____cpython', 'linux', 'x64', 'self-hosted']
+            runs_on: ['ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_python3.12.____cpython
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_python3.12.____cpython', 'linux', 'x64', 'self-hosted']
+            runs_on: ['ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_python3.13.____cp313
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_python3.13.____cp313', 'linux', 'x64', 'self-hosted']
+            runs_on: ['ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
     steps:
 

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -25,17 +25,17 @@ jobs:
           - CONFIG: linux_64_python3.11.____cpython
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_python3.11.____cpython']
+            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_python3.11.____cpython', 'linux', 'x64', 'self-hosted']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_python3.12.____cpython
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_python3.12.____cpython']
+            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_python3.12.____cpython', 'linux', 'x64', 'self-hosted']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_python3.13.____cp313
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_python3.13.____cp313']
+            runs_on: ['cirun-openstack-cpu-4xlarge--${{ github.run_id }}-linux_64_python3.13.____cp313', 'linux', 'x64', 'self-hosted']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
     steps:
 

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -20,6 +20,7 @@ export PYTHONUNBUFFERED=1
 export RECIPE_ROOT="${RECIPE_ROOT:-/home/conda/recipe_root}"
 export CI_SUPPORT="${FEEDSTOCK_ROOT}/.ci_support"
 export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
+export RATTLER_CACHE_DIR="${FEEDSTOCK_ROOT}/build_artifacts/pkg_cache"
 
 cat >~/.condarc <<CONDARC
 

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -11,6 +11,8 @@ source .scripts/logging_utils.sh
 
 set -xeo pipefail
 
+DOCKER_EXECUTABLE="${DOCKER_EXECUTABLE:-docker}"
+
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
 PROVIDER_DIR="$(basename "$THISDIR")"
 
@@ -27,7 +29,7 @@ if [[ "${sha:-}" == "" ]]; then
   popd
 fi
 
-docker info
+${DOCKER_EXECUTABLE} info
 
 # In order for the conda-build process in the container to write to the mounted
 # volumes, we need to run with the same id as the host machine, which is
@@ -35,6 +37,7 @@ docker info
 export HOST_USER_ID=$(id -u)
 # Check if docker-machine is being used (normally on OSX) and get the uid from
 # the VM
+
 if hash docker-machine 2> /dev/null && docker-machine active > /dev/null; then
     export HOST_USER_ID=$(docker-machine ssh $(docker-machine active) id -u)
 fi
@@ -76,16 +79,34 @@ if [ -z "${CI}" ]; then
     DOCKER_RUN_ARGS="-it ${DOCKER_RUN_ARGS}"
 fi
 
-( endgroup "Configure Docker" ) 2> /dev/null
+# Default volume suffix for Docker (preserve original behavior)
+VOLUME_SUFFIX=",z"
 
+# Podman-specific handling
+if [ "${DOCKER_EXECUTABLE}" = "podman" ]; then
+    # Fix file permissions for rootless podman builds
+    podman unshare chown -R ${HOST_USER_ID}:${HOST_USER_ID} "${ARTIFACTS}"
+    podman unshare chown -R ${HOST_USER_ID}:${HOST_USER_ID} "${RECIPE_ROOT}"
+
+    # Add SELinux label only if enforcing
+    if command -v getenforce &>/dev/null && [ "$(getenforce)" = "Enforcing" ]; then
+        VOLUME_SUFFIX=",z"
+    else
+        VOLUME_SUFFIX=""
+    fi
+fi
+
+( endgroup "Configure Docker" ) 2> /dev/null
 ( startgroup "Start Docker" ) 2> /dev/null
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 export IS_PR_BUILD="${IS_PR_BUILD:-False}"
-docker pull "${DOCKER_IMAGE}"
-docker run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
+
+${DOCKER_EXECUTABLE} pull "${DOCKER_IMAGE}"
+
+${DOCKER_EXECUTABLE} run ${DOCKER_RUN_ARGS} \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw${VOLUME_SUFFIX},delegated \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw${VOLUME_SUFFIX},delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \

--- a/build-locally.py
+++ b/build-locally.py
@@ -28,13 +28,6 @@ def setup_environment(ns):
             os.path.dirname(__file__), "miniforge3"
         )
 
-    # The default cache location might not be writable using docker on macOS.
-    if ns.config.startswith("linux") and platform.system() == "Darwin":
-        os.environ["CONDA_FORGE_DOCKER_RUN_ARGS"] = (
-            os.environ.get("CONDA_FORGE_DOCKER_RUN_ARGS", "")
-            + " -e RATTLER_CACHE_DIR=/tmp/rattler_cache"
-        )
-
 
 def run_docker_build(ns):
     script = ".scripts/run_docker_build.sh"

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -14,7 +14,6 @@ github:
   tooling_branch_name: main
 test: native_and_emulated
 github_actions:
-  self_hosted: true
   triggers:
     - push
     - pull_request

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,7 +5,7 @@
 
 [workspace]
 name = "ray-packages-feedstock"
-version = "3.58.0"  # conda-smithy version used to generate this file
+version = "3.58.1"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/ray-packages-feedstock"
 authors = ["@conda-forge/ray-packages"]
 channels = ["conda-forge"]

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,7 +5,7 @@
 
 [workspace]
 name = "ray-packages-feedstock"
-version = "3.55.1"  # conda-smithy version used to generate this file
+version = "3.58.0"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/ray-packages-feedstock"
 authors = ["@conda-forge/ray-packages"]
 channels = ["conda-forge"]

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,7 +5,7 @@
 
 [workspace]
 name = "ray-packages-feedstock"
-version = "3.58.1"  # conda-smithy version used to generate this file
+version = "3.59.0"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/ray-packages-feedstock"
 authors = ["@conda-forge/ray-packages"]
 channels = ["conda-forge"]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,7 +1,7 @@
 c_stdlib_version:         # [osx and x86_64]
-- '10.15'                 # [osx and x86_64]
+- '11.0'                  # [osx and x86_64]
 MACOSX_SDK_VERSION:       # [osx and x86_64]
-- '10.15'                 # [osx and x86_64]
+- '11.0'                  # [osx and x86_64]
 
-github_actions_labels:          # [linux]
-- cirun-openstack-cpu-4xlarge   # [linux]
+github_actions_labels:                    # [linux]
+- self-hosted@cirun-openstack-cpu-4xlarge # [linux]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,5 +3,5 @@ c_stdlib_version:         # [osx and x86_64]
 MACOSX_SDK_VERSION:       # [osx and x86_64]
 - '11.0'                  # [osx and x86_64]
 
-github_actions_labels:                    # [linux]
-- self-hosted@cirun-openstack-cpu-4xlarge # [linux]
+github_actions_labels:                             # [linux]
+- ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg  # [linux]

--- a/recipe/patches/0001-Disable-making-entry-scripts.patch
+++ b/recipe/patches/0001-Disable-making-entry-scripts.patch
@@ -1,4 +1,4 @@
-From 4ea353b251cd87739ec7ad0f2730acb1cdaa8a3e Mon Sep 17 00:00:00 2001
+From 12f98ac3a15fe2600c73acf0eac4a4d07b53a162 Mon Sep 17 00:00:00 2001
 From: Vasily Litvinov <vasilij.n.litvinov@intel.com>
 Date: Tue, 10 Nov 2020 23:26:35 +0300
 Subject: [PATCH 01/10] Disable making entry scripts

--- a/recipe/patches/0002-Ignore-warnings-in-event.cc-and-logging.cc.patch
+++ b/recipe/patches/0002-Ignore-warnings-in-event.cc-and-logging.cc.patch
@@ -1,4 +1,4 @@
-From 9411ca6f180130bc1b02b674f4f231cb8f2caca2 Mon Sep 17 00:00:00 2001
+From b1ea91812745adff21ee1d83740c879aed743b92 Mon Sep 17 00:00:00 2001
 From: Vasily Litvinov <vasilij.n.litvinov@intel.com>
 Date: Fri, 9 May 2025 13:12:32 +0300
 Subject: [PATCH 02/10] Ignore warnings in event.cc and logging.cc

--- a/recipe/patches/0003-fake-python-3.10-with-python-3.12.patch
+++ b/recipe/patches/0003-fake-python-3.10-with-python-3.12.patch
@@ -1,4 +1,4 @@
-From ae55eaa084733e2738a6e9eacb5bc8c465fcafca Mon Sep 17 00:00:00 2001
+From 6ba614706989b24a89fe5ae74b0021e916320aab Mon Sep 17 00:00:00 2001
 From: Lonnie Liu <lonnie@anyscale.com>
 Date: Thu, 27 Nov 2025 02:30:45 +0000
 Subject: [PATCH 03/10] fake python 3.10 with python 3.12

--- a/recipe/patches/0004-Vendor-grpc-1.67.1.patch
+++ b/recipe/patches/0004-Vendor-grpc-1.67.1.patch
@@ -1,4 +1,4 @@
-From cf5574d2d90956a827e813b2ab6b887d5a1f7af6 Mon Sep 17 00:00:00 2001
+From eb03a0d2fcbb59d0e036c255bc582ec7dfecaaa5 Mon Sep 17 00:00:00 2001
 From: Austin Morton <austin.morton@aquatic.com>
 Date: Wed, 15 Oct 2025 16:12:56 +0000
 Subject: [PATCH 04/10] Vendor grpc 1.67.1

--- a/recipe/patches/0005-remove-stdlib-libc-from-.bazelrc.patch
+++ b/recipe/patches/0005-remove-stdlib-libc-from-.bazelrc.patch
@@ -1,4 +1,4 @@
-From 86ba717c8e478d05f7f6cc30e1160c35dfbbfc00 Mon Sep 17 00:00:00 2001
+From 43e4847d2e87791b359d9ae9b3d2e49ee9005aee Mon Sep 17 00:00:00 2001
 From: Matti Picus <matti.picus@gmail.com>
 Date: Thu, 9 May 2024 05:13:50 +1000
 Subject: [PATCH 05/10] remove stdlib=libc++ from .bazelrc

--- a/recipe/patches/0006-patch-protobuf-use-of-nan-on-windows.patch
+++ b/recipe/patches/0006-patch-protobuf-use-of-nan-on-windows.patch
@@ -1,4 +1,4 @@
-From 01f184e204dcae0a08c7456431ab63998d275416 Mon Sep 17 00:00:00 2001
+From cb5993ed102bf0f705192c3457a48521c2efeae7 Mon Sep 17 00:00:00 2001
 From: Matti Picus <matti.picus@gmail.com>
 Date: Wed, 5 Feb 2025 22:39:59 +1100
 Subject: [PATCH 06/10] patch protobuf use of nan on windows

--- a/recipe/patches/0007-patch-zlib-in-prometheus-cpp-and-boost.patch
+++ b/recipe/patches/0007-patch-zlib-in-prometheus-cpp-and-boost.patch
@@ -1,4 +1,4 @@
-From 3c3caa98b6672be46d86802281b386a8626921a5 Mon Sep 17 00:00:00 2001
+From e2ab139e590a6e4d85d8076c295ac86d055f8def Mon Sep 17 00:00:00 2001
 From: Matti Picus <matti.picus@gmail.com>
 Date: Fri, 29 Aug 2025 00:16:11 +0300
 Subject: [PATCH 07/10] patch zlib in prometheus-cpp and boost

--- a/recipe/patches/0008-bazel-disable-strict-env.patch
+++ b/recipe/patches/0008-bazel-disable-strict-env.patch
@@ -1,4 +1,4 @@
-From f9cb242bcffc276e2df95a8dfa338a9d38a5d526 Mon Sep 17 00:00:00 2001
+From 58a0c6933bc6b1c93f663ea92d3a47a9a94f0024 Mon Sep 17 00:00:00 2001
 From: Lonnie Liu <lonnie@anyscale.com>
 Date: Wed, 15 Oct 2025 16:30:33 +0000
 Subject: [PATCH 08/10] [bazel] disable strict env

--- a/recipe/patches/0009-fix-symbols.patch
+++ b/recipe/patches/0009-fix-symbols.patch
@@ -1,4 +1,4 @@
-From dd6cf8e3b47ec50f6086a2b0d0f3e94b9e0d1b2f Mon Sep 17 00:00:00 2001
+From 25ec6176930353a72c3b404053bae9ed41886bb7 Mon Sep 17 00:00:00 2001
 From: Rueian Huang <rueian@gmail.com>
 Date: Thu, 19 Feb 2026 16:21:07 -0800
 Subject: [PATCH 09/10] fix symbols

--- a/recipe/patches/0010-use-compiler_param_file-on-Windows-to-avoid-CreatePr.patch
+++ b/recipe/patches/0010-use-compiler_param_file-on-Windows-to-avoid-CreatePr.patch
@@ -1,4 +1,4 @@
-From dcc9456fafa39f0262e9f292ee160f04114ac82c Mon Sep 17 00:00:00 2001
+From 1ef77fe7fab9501740ceb590ea79b3ef7eca4395 Mon Sep 17 00:00:00 2001
 From: andrew <andrew@anyscale.com>
 Date: Wed, 25 Feb 2026 13:59:45 -0800
 Subject: [PATCH 10/10] use compiler_param_file on Windows to avoid

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,7 +2,7 @@
 schema_version: 1
 
 context:
-  version: "2.54.0"
+  version: "2.54.1"
 
 recipe:
   name: ray-packages
@@ -10,7 +10,7 @@ recipe:
 
 source:
   url: https://github.com/ray-project/ray/archive/ray-${{ version }}.tar.gz
-  sha256: 3417142d8d46af16ca556c687b21c11812264dd98201935cc0af34b37773b30b
+  sha256: 40e1d0f9c65c10c910c037bea151b1b9827c2b652704e67e49e6a083cc2b178b
   patches:
     - patches/0001-Disable-making-entry-scripts.patch
     - patches/0002-Ignore-warnings-in-event.cc-and-logging.cc.patch
@@ -213,10 +213,9 @@ outputs:
           # ray stop on Windows fails to kill dashboard and runtime_env agents;
           # force-kill remaining ray python processes and wait for handles to release
           - if: win
-            then: wmic process where "name='python.exe' and commandline like '%%ray%%'" delete || ver >nul
-          - if: win
-            then: powershell -c "Start-Sleep 15"
-
+            then:
+              - wmic process where "name='python.exe' and commandline like '%%ray%%'" delete || ver >nul
+              - powershell -c "Start-Sleep 15"
   - package:
       name: ray-client
     requirements:
@@ -238,10 +237,9 @@ outputs:
           # ray stop on Windows fails to kill dashboard and runtime_env agents;
           # force-kill remaining ray python processes and wait for handles to release
           - if: win
-            then: wmic process where "name='python.exe' and commandline like '%%ray%%'" delete || ver >nul
-          - if: win
-            then: powershell -c "Start-Sleep 15"
-
+            then:
+              - wmic process where "name='python.exe' and commandline like '%%ray%%'" delete || ver >nul
+              - powershell -c "Start-Sleep 15"
   - package:
       name: ray-rllib
     requirements:


### PR DESCRIPTION
## Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] N/A: Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered](https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

## Changes
- Patch 0004 (Vendor grpc 1.67.1): updated context to match 2.54.0's auto_http_archive
- Patch 0003 (fake python 3.10): dropped removed python3_9 block
- Patch 0006 (protobuf NaN): updated context for new protobuf block format
- Various updates from `conda-smithy` upgrade

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Signed-off-by: andrew <andrew@anyscale.com>
