### PR TITLE
Enable linux-aarch64 builds

### DIFF
--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -17,9 +17,9 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-aarch64:alma9
 github_actions_labels:
-- blacksmith-16vcpu-ubuntu-2404
+- blacksmith-16vcpu-ubuntu-2404-arm
 libgrpc:
 - '1.73'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+curl:
+- '8'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+github_actions_labels:
+- blacksmith-16vcpu-ubuntu-2404
+libgrpc:
+- '1.73'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpython.yaml
@@ -17,9 +17,9 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-aarch64:alma9
 github_actions_labels:
-- blacksmith-16vcpu-ubuntu-2404
+- blacksmith-16vcpu-ubuntu-2404-arm
 libgrpc:
 - '1.73'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpython.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+curl:
+- '8'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+github_actions_labels:
+- blacksmith-16vcpu-ubuntu-2404
+libgrpc:
+- '1.73'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_python3.13.____cp313.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+curl:
+- '8'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+github_actions_labels:
+- blacksmith-16vcpu-ubuntu-2404
+libgrpc:
+- '1.73'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.13.* *_cp313
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_python3.13.____cp313.yaml
@@ -17,9 +17,9 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-aarch64:alma9
 github_actions_labels:
-- blacksmith-16vcpu-ubuntu-2404
+- blacksmith-16vcpu-ubuntu-2404-arm
 libgrpc:
 - '1.73'
 pin_run_as_build:

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -44,20 +44,20 @@ jobs:
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['blacksmith-16vcpu-ubuntu-2404']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            runs_on: ['blacksmith-16vcpu-ubuntu-2404-arm']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
           - CONFIG: linux_aarch64_python3.12.____cpython
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['blacksmith-16vcpu-ubuntu-2404']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            runs_on: ['blacksmith-16vcpu-ubuntu-2404-arm']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
           - CONFIG: linux_aarch64_python3.13.____cp313
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
-            runs_on: ['blacksmith-16vcpu-ubuntu-2404']
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            runs_on: ['blacksmith-16vcpu-ubuntu-2404-arm']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
     steps:
 
     - name: Checkout code

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -40,6 +40,24 @@ jobs:
             os: ubuntu
             runs_on: ['blacksmith-16vcpu-ubuntu-2404']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+          - CONFIG: linux_aarch64_python3.11.____cpython
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['blacksmith-16vcpu-ubuntu-2404']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+          - CONFIG: linux_aarch64_python3.12.____cpython
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['blacksmith-16vcpu-ubuntu-2404']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+          - CONFIG: linux_aarch64_python3.13.____cp313
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['blacksmith-16vcpu-ubuntu-2404']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
     steps:
 
     - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -58,6 +58,27 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_aarch64_python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11419&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ray-packages-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11419&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ray-packages-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_python3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11419&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ray-packages-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64_python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11419&branchName=main">

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -5,6 +5,7 @@ azure:
       CONDA_BLD_PATH: C:\\bld\\
       MINIFORGE_HOME: C:\Miniforge
 build_platform:
+  linux_aarch64: linux_64
   osx_arm64: osx_64
 conda_build:
   pkg_format: '2'
@@ -18,6 +19,7 @@ github_actions:
     - push
     - pull_request
 provider:
+  linux_aarch64: github_actions
   linux_64: github_actions
 conda_install_tool: pixi
 conda_build_tool: rattler-build

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -5,7 +5,6 @@ azure:
       CONDA_BLD_PATH: C:\\bld\\
       MINIFORGE_HOME: C:\Miniforge
 build_platform:
-  linux_aarch64: linux_64
   osx_arm64: osx_64
 conda_build:
   pkg_format: '2'
@@ -19,7 +18,6 @@ github_actions:
     - push
     - pull_request
 provider:
-  linux_aarch64: github_actions
-  linux_64: github_actions
+  linux_aarch64: default
 conda_install_tool: pixi
 conda_build_tool: rattler-build

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,11 +5,11 @@
 
 [workspace]
 name = "ray-packages-feedstock"
-version = "3.61.0"  # conda-smithy version used to generate this file
+version = "3.61.1"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/ray-packages-feedstock"
 authors = ["@conda-forge/ray-packages"]
 channels = ["conda-forge"]
-platforms = ["linux-64", "osx-64", "win-64"]
+platforms = ["linux-64", "linux-aarch64", "osx-64", "win-64"]
 requires-pixi = ">=0.59.0"
 
 [dependencies]
@@ -41,6 +41,24 @@ description = "Build ray-packages-feedstock with variant linux_64_python3.13.___
 [tasks."inspect-linux_64_python3.13.____cp313"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.13.____cp313.yaml"
 description = "List contents of ray-packages-feedstock packages built for variant linux_64_python3.13.____cp313"
+[tasks."build-linux_aarch64_python3.11.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_python3.11.____cpython.yaml"
+description = "Build ray-packages-feedstock with variant linux_aarch64_python3.11.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_python3.11.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_python3.11.____cpython.yaml"
+description = "List contents of ray-packages-feedstock packages built for variant linux_aarch64_python3.11.____cpython"
+[tasks."build-linux_aarch64_python3.12.____cpython"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_python3.12.____cpython.yaml"
+description = "Build ray-packages-feedstock with variant linux_aarch64_python3.12.____cpython directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_python3.12.____cpython"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_python3.12.____cpython.yaml"
+description = "List contents of ray-packages-feedstock packages built for variant linux_aarch64_python3.12.____cpython"
+[tasks."build-linux_aarch64_python3.13.____cp313"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_python3.13.____cp313.yaml"
+description = "Build ray-packages-feedstock with variant linux_aarch64_python3.13.____cp313 directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_python3.13.____cp313"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_python3.13.____cp313.yaml"
+description = "List contents of ray-packages-feedstock packages built for variant linux_aarch64_python3.13.____cp313"
 [tasks."build-osx_64_python3.11.____cpython"]
 cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_python3.11.____cpython.yaml"
 description = "Build ray-packages-feedstock with variant osx_64_python3.11.____cpython directly (without setup scripts)"

--- a/recipe/build-core.sh
+++ b/recipe/build-core.sh
@@ -30,15 +30,6 @@ fi
 export LDFLAGS="${LDFLAGS} -lm"
 source gen-bazel-toolchain
 
-if [[ "${target_platform}" != "${build_platform}" ]]; then
-  export CONFIG_SITE="${BUILD_PREFIX}/${HOST}/sysroot/usr/share/config.site"
-  export ac_cv_func_malloc_0_nonnull=yes
-  export ac_cv_func_realloc_0_nonnull=yes
-  export ac_cv_c_bigendian=no
-  export build="${BUILD}"
-  export host="${HOST}"
-fi
-
 # bazel-toolchain 0.5.x uses load paths (e.g. @rules_cc//cc/toolchains:... and
 # @rules_cc//cc/common:...) that only exist in rules_cc 0.0.10+. Our grpc 1.67.1
 # vendoring pins rules_cc 0.0.9, where cc_toolchain / cc_common / CcToolchainConfigInfo

--- a/recipe/build-core.sh
+++ b/recipe/build-core.sh
@@ -30,6 +30,15 @@ fi
 export LDFLAGS="${LDFLAGS} -lm"
 source gen-bazel-toolchain
 
+if [[ "${target_platform}" != "${build_platform}" ]]; then
+  export CONFIG_SITE="${BUILD_PREFIX}/${HOST}/sysroot/usr/share/config.site"
+  export ac_cv_func_malloc_0_nonnull=yes
+  export ac_cv_func_realloc_0_nonnull=yes
+  export ac_cv_c_bigendian=no
+  export build="${BUILD}"
+  export host="${HOST}"
+fi
+
 # bazel-toolchain 0.5.x uses load paths (e.g. @rules_cc//cc/toolchains:... and
 # @rules_cc//cc/common:...) that only exist in rules_cc 0.0.10+. Our grpc 1.67.1
 # vendoring pins rules_cc 0.0.9, where cc_toolchain / cc_common / CcToolchainConfigInfo

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,4 +4,5 @@ MACOSX_SDK_VERSION:       # [osx and x86_64]
 - '11.0'                  # [osx and x86_64]
 
 github_actions_labels:                 # [linux]
-- blacksmith-16vcpu-ubuntu-2404        # [linux]
+- blacksmith-16vcpu-ubuntu-2404        # [linux and x86_64]
+- blacksmith-16vcpu-ubuntu-2404-arm    # [linux and aarch64]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -27,7 +27,7 @@ source:
     - patches/0008-bazel-disable-strict-env.patch
 
 build:
-  number: 0
+  number: 1
   skip:
     - match(python, "<3.11")
 


### PR DESCRIPTION
Checklist
* [x] Used a personal fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Re-rendered with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

## Summary
- enable `linux_aarch64` in `conda-forge.yml` and rerender the feedstock with `conda-smithy`
- add the generated `linux_aarch64` CI variants, workflow entries, and pixi tasks
- bump the build number to `1`

## Validation
- rerendered locally with `conda-smithy`
- built `linux_aarch64_python3.13.____cp313` locally with `rattler-build`

My best guess is that something has been fixed upstream between the previous attempts to enable aarch64 and now. I asked the bot to retry #211 but it didn't seem to trigger after ~48 hours so I gave it a shot manually.

Supersedes #211 and #235.