### PR TITLE
Rebuild for libabseil 20260107, libgrpc 1.78 & libprotobuf 6.33.5

### DIFF
--- a/.ci_support/linux_64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_python3.11.____cpython.yaml
@@ -21,7 +21,7 @@ docker_image:
 github_actions_labels:
 - blacksmith-16vcpu-ubuntu-2404
 libgrpc:
-- '1.73'
+- '1.78'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_python3.12.____cpython.yaml
@@ -21,7 +21,7 @@ docker_image:
 github_actions_labels:
 - blacksmith-16vcpu-ubuntu-2404
 libgrpc:
-- '1.73'
+- '1.78'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_python3.13.____cp313.yaml
@@ -21,7 +21,7 @@ docker_image:
 github_actions_labels:
 - blacksmith-16vcpu-ubuntu-2404
 libgrpc:
-- '1.73'
+- '1.78'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.11.____cpython.yaml
@@ -21,7 +21,7 @@ docker_image:
 github_actions_labels:
 - blacksmith-16vcpu-ubuntu-2404-arm
 libgrpc:
-- '1.73'
+- '1.78'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.12.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.12.____cpython.yaml
@@ -21,7 +21,7 @@ docker_image:
 github_actions_labels:
 - blacksmith-16vcpu-ubuntu-2404-arm
 libgrpc:
-- '1.73'
+- '1.78'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_aarch64_python3.13.____cp313.yaml
+++ b/.ci_support/linux_aarch64_python3.13.____cp313.yaml
@@ -21,7 +21,7 @@ docker_image:
 github_actions_labels:
 - blacksmith-16vcpu-ubuntu-2404-arm
 libgrpc:
-- '1.73'
+- '1.78'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/migrations/absl_grpc_proto_26Q1.yaml
+++ b/.ci_support/migrations/absl_grpc_proto_26Q1.yaml
@@ -1,0 +1,26 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for libabseil 20260107, libgrpc 1.78 & libprotobuf 6.33.5
+  kind: version
+  migration_number: 1
+  exclude:
+    # core deps
+    - abseil-cpp
+    - grpc-cpp
+    - libprotobuf
+    # required for building/testing
+    - protobuf
+    - re2
+    # bazel stack
+    - bazel
+    - grpc_java_plugin
+    - singlejar
+    # built manually beforehand due to enormous build time
+    - pytorch-cpu
+libabseil:
+- 20260107
+libgrpc:
+- "1.78"
+libprotobuf:
+- 6.33.5
+migrator_ts: 1768184504.2078037

--- a/.ci_support/osx_64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_python3.11.____cpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '19'
 libgrpc:
-- '1.73'
+- '1.78'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_python3.12.____cpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '19'
 libgrpc:
-- '1.73'
+- '1.78'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_python3.13.____cp313.yaml
@@ -21,7 +21,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '19'
 libgrpc:
-- '1.73'
+- '1.78'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.11.____cpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '19'
 libgrpc:
-- '1.73'
+- '1.78'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.12.____cpython.yaml
@@ -21,7 +21,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '19'
 libgrpc:
-- '1.73'
+- '1.78'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/osx_arm64_python3.13.____cp313.yaml
+++ b/.ci_support/osx_arm64_python3.13.____cp313.yaml
@@ -21,7 +21,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '19'
 libgrpc:
-- '1.73'
+- '1.78'
 macos_machine:
 - arm64-apple-darwin20.0.0
 pin_run_as_build:

--- a/.ci_support/win_64_python3.11.____cpython.yaml
+++ b/.ci_support/win_64_python3.11.____cpython.yaml
@@ -11,7 +11,7 @@ curl:
 cxx_compiler:
 - vs2022
 libgrpc:
-- '1.73'
+- '1.78'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.12.____cpython.yaml
+++ b/.ci_support/win_64_python3.12.____cpython.yaml
@@ -11,7 +11,7 @@ curl:
 cxx_compiler:
 - vs2022
 libgrpc:
-- '1.73'
+- '1.78'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/win_64_python3.13.____cp313.yaml
+++ b/.ci_support/win_64_python3.13.____cp313.yaml
@@ -11,7 +11,7 @@ curl:
 cxx_compiler:
 - vs2022
 libgrpc:
-- '1.73'
+- '1.78'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!.recipe_maintainers.json
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/README.md
+++ b/README.md
@@ -286,7 +286,6 @@ Feedstock Maintainers
 * [@aslonnie](https://github.com/aslonnie/)
 * [@dHannasch](https://github.com/dHannasch/)
 * [@h-vetinari](https://github.com/h-vetinari/)
-* [@mattip](https://github.com/mattip/)
 * [@timkpaine](https://github.com/timkpaine/)
 * [@vnlitvinov](https://github.com/vnlitvinov/)
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,7 +5,7 @@
 
 [workspace]
 name = "ray-packages-feedstock"
-version = "3.61.1"  # conda-smithy version used to generate this file
+version = "3.61.2"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/ray-packages-feedstock"
 authors = ["@conda-forge/ray-packages"]
 channels = ["conda-forge"]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -27,7 +27,7 @@ source:
     - patches/0008-bazel-disable-strict-env.patch
 
 build:
-  number: 1
+  number: 2
   skip:
     - match(python, "<3.11")
 


### PR DESCRIPTION
## Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (build number bumped from 1 → 2)
* [x] [Re-rendered](https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks) with the latest `conda-smithy` (3.61.2)
* [x] Ensured the license file is being packaged.

## Summary
Picks up the absl_grpc_proto_26Q1 migration: libabseil 20260107, libgrpc 1.78, libprotobuf 6.33.5. Supersedes #275 (rebased onto current main, which has linux-aarch64 from #271 already merged).

## Notes
- Build number bumped to 2 (was 1 after #271 landed, migration needs a fresh number to trigger rebuild).
- conda-forge.yml conflict from #275 resolved by keeping the post-aarch64 state (`linux_aarch64: default`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)