### PR TITLE
Migrator to enable Python 3.14

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -23,6 +23,11 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
         store_build_artifacts: false
+      osx_64_python3.14.____cp314:
+        CONFIG: osx_64_python3.14.____cp314
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_arm64_python3.11.____cpython:
         CONFIG: osx_arm64_python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
@@ -35,6 +40,11 @@ jobs:
         store_build_artifacts: false
       osx_arm64_python3.13.____cp313:
         CONFIG: osx_arm64_python3.13.____cp313
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15
+        store_build_artifacts: false
+      osx_arm64_python3.14.____cp314:
+        CONFIG: osx_arm64_python3.14.____cp314
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
         store_build_artifacts: false

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -20,6 +20,10 @@ jobs:
         CONFIG: win_64_python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
         store_build_artifacts: false
+      win_64_python3.14.____cp314:
+        CONFIG: win_64_python3.14.____cp314
+        UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: C:\\bld\\

--- a/.ci_support/linux_64_python3.14.____cp314.yaml
+++ b/.ci_support/linux_64_python3.14.____cp314.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+curl:
+- '8'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+github_actions_labels:
+- blacksmith-16vcpu-ubuntu-2404
+libgrpc:
+- '1.78'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_python3.14.____cp314.yaml
+++ b/.ci_support/linux_aarch64_python3.14.____cp314.yaml
@@ -1,0 +1,35 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '14'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+curl:
+- '8'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64:alma9
+github_actions_labels:
+- blacksmith-16vcpu-ubuntu-2404-arm
+libgrpc:
+- '1.78'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/migrations/python314.yaml
+++ b/.ci_support/migrations/python314.yaml
@@ -1,0 +1,41 @@
+# this is intentionally sorted before the 3.13t migrator, because that determines
+# the order of application of the migrators; otherwise we'd have to add values for
+# is_freethreading and is_abi3 keys here, since that migration extends the zip;
+migrator_ts: 1724712607
+__migrator:
+    commit_message: Rebuild for python 3.14
+    migration_number: 1
+    operation: key_add
+    primary_key: python
+    ordering:
+        python:
+            - 3.9.* *_cpython
+            - 3.10.* *_cpython
+            - 3.11.* *_cpython
+            - 3.12.* *_cpython
+            - 3.13.* *_cp313
+            - 3.13.* *_cp313t
+            - 3.14.* *_cp314
+    paused: false
+    longterm: true
+    pr_limit: 5
+    max_solver_attempts: 3
+    exclude:
+        # this shouldn't attempt to modify the python feedstocks
+        - python
+        - pypy3.6
+        - pypy-meta
+        - cross-python
+        - python_abi
+        # Manually migrated (e.g. were blocked on missing dev dependencies)
+        - pyarrow
+    exclude_pinned_pkgs: false
+    ignored_deps_per_node:
+        matplotlib:
+            - pyqt
+
+python:
+- 3.14.* *_cp314
+# additional entries to add for zip_keys
+is_python_min:
+- false

--- a/.ci_support/osx_64_python3.14.____cp314.yaml
+++ b/.ci_support/osx_64_python3.14.____cp314.yaml
@@ -1,0 +1,37 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+curl:
+- '8'
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+libgrpc:
+- '1.78'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
+target_platform:
+- osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_python3.14.____cp314.yaml
+++ b/.ci_support/osx_arm64_python3.14.____cp314.yaml
@@ -1,0 +1,37 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+curl:
+- '8'
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+libgrpc:
+- '1.78'
+macos_machine:
+- arm64-apple-darwin20.0.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/win_64_python3.14.____cp314.yaml
+++ b/.ci_support/win_64_python3.14.____cp314.yaml
@@ -1,0 +1,22 @@
+c_compiler:
+- vs2022
+c_stdlib:
+- vs
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+curl:
+- '8'
+cxx_compiler:
+- vs2022
+libgrpc:
+- '1.78'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.14.* *_cp314
+target_platform:
+- win-64

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -40,6 +40,12 @@ jobs:
             os: ubuntu
             runs_on: ['blacksmith-16vcpu-ubuntu-2404']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+          - CONFIG: linux_64_python3.14.____cp314
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['blacksmith-16vcpu-ubuntu-2404']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_aarch64_python3.11.____cpython
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
@@ -53,6 +59,12 @@ jobs:
             runs_on: ['blacksmith-16vcpu-ubuntu-2404-arm']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
           - CONFIG: linux_aarch64_python3.13.____cp313
+            STORE_BUILD_ARTIFACTS: False
+            UPLOAD_PACKAGES: True
+            os: ubuntu
+            runs_on: ['blacksmith-16vcpu-ubuntu-2404-arm']
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64:alma9
+          - CONFIG: linux_aarch64_python3.14.____cp314
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_64_python3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11419&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ray-packages-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_python3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_aarch64_python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11419&branchName=main">
@@ -76,6 +83,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11419&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ray-packages-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_python3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11419&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ray-packages-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_python3.14.____cp314" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -100,6 +114,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_64_python3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11419&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ray-packages-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_python3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_arm64_python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11419&branchName=main">
@@ -121,6 +142,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_arm64_python3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11419&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ray-packages-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_python3.14.____cp314" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>win_64_python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11419&branchName=main">
@@ -139,6 +167,13 @@ Current build status
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11419&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ray-packages-feedstock?branchName=main&jobName=win&configuration=win%20win_64_python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_python3.14.____cp314</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11419&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ray-packages-feedstock?branchName=main&jobName=win&configuration=win%20win_64_python3.14.____cp314" alt="variant">
                 </a>
               </td>
             </tr>

--- a/pixi.toml
+++ b/pixi.toml
@@ -41,6 +41,12 @@ description = "Build ray-packages-feedstock with variant linux_64_python3.13.___
 [tasks."inspect-linux_64_python3.13.____cp313"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.13.____cp313.yaml"
 description = "List contents of ray-packages-feedstock packages built for variant linux_64_python3.13.____cp313"
+[tasks."build-linux_64_python3.14.____cp314"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_python3.14.____cp314.yaml"
+description = "Build ray-packages-feedstock with variant linux_64_python3.14.____cp314 directly (without setup scripts)"
+[tasks."inspect-linux_64_python3.14.____cp314"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_python3.14.____cp314.yaml"
+description = "List contents of ray-packages-feedstock packages built for variant linux_64_python3.14.____cp314"
 [tasks."build-linux_aarch64_python3.11.____cpython"]
 cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_python3.11.____cpython.yaml"
 description = "Build ray-packages-feedstock with variant linux_aarch64_python3.11.____cpython directly (without setup scripts)"
@@ -59,6 +65,12 @@ description = "Build ray-packages-feedstock with variant linux_aarch64_python3.1
 [tasks."inspect-linux_aarch64_python3.13.____cp313"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_python3.13.____cp313.yaml"
 description = "List contents of ray-packages-feedstock packages built for variant linux_aarch64_python3.13.____cp313"
+[tasks."build-linux_aarch64_python3.14.____cp314"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_python3.14.____cp314.yaml"
+description = "Build ray-packages-feedstock with variant linux_aarch64_python3.14.____cp314 directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_python3.14.____cp314"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_python3.14.____cp314.yaml"
+description = "List contents of ray-packages-feedstock packages built for variant linux_aarch64_python3.14.____cp314"
 [tasks."build-osx_64_python3.11.____cpython"]
 cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_python3.11.____cpython.yaml"
 description = "Build ray-packages-feedstock with variant osx_64_python3.11.____cpython directly (without setup scripts)"
@@ -77,6 +89,12 @@ description = "Build ray-packages-feedstock with variant osx_64_python3.13.____c
 [tasks."inspect-osx_64_python3.13.____cp313"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_python3.13.____cp313.yaml"
 description = "List contents of ray-packages-feedstock packages built for variant osx_64_python3.13.____cp313"
+[tasks."build-osx_64_python3.14.____cp314"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_python3.14.____cp314.yaml"
+description = "Build ray-packages-feedstock with variant osx_64_python3.14.____cp314 directly (without setup scripts)"
+[tasks."inspect-osx_64_python3.14.____cp314"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_python3.14.____cp314.yaml"
+description = "List contents of ray-packages-feedstock packages built for variant osx_64_python3.14.____cp314"
 [tasks."build-osx_arm64_python3.11.____cpython"]
 cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_python3.11.____cpython.yaml"
 description = "Build ray-packages-feedstock with variant osx_arm64_python3.11.____cpython directly (without setup scripts)"
@@ -95,6 +113,12 @@ description = "Build ray-packages-feedstock with variant osx_arm64_python3.13.__
 [tasks."inspect-osx_arm64_python3.13.____cp313"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.13.____cp313.yaml"
 description = "List contents of ray-packages-feedstock packages built for variant osx_arm64_python3.13.____cp313"
+[tasks."build-osx_arm64_python3.14.____cp314"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_python3.14.____cp314.yaml"
+description = "Build ray-packages-feedstock with variant osx_arm64_python3.14.____cp314 directly (without setup scripts)"
+[tasks."inspect-osx_arm64_python3.14.____cp314"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_python3.14.____cp314.yaml"
+description = "List contents of ray-packages-feedstock packages built for variant osx_arm64_python3.14.____cp314"
 [tasks."build-win_64_python3.11.____cpython"]
 cmd = "rattler-build build --recipe recipe -m .ci_support/win_64_python3.11.____cpython.yaml"
 description = "Build ray-packages-feedstock with variant win_64_python3.11.____cpython directly (without setup scripts)"
@@ -113,6 +137,12 @@ description = "Build ray-packages-feedstock with variant win_64_python3.13.____c
 [tasks."inspect-win_64_python3.13.____cp313"]
 cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_python3.13.____cp313.yaml"
 description = "List contents of ray-packages-feedstock packages built for variant win_64_python3.13.____cp313"
+[tasks."build-win_64_python3.14.____cp314"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/win_64_python3.14.____cp314.yaml"
+description = "Build ray-packages-feedstock with variant win_64_python3.14.____cp314 directly (without setup scripts)"
+[tasks."inspect-win_64_python3.14.____cp314"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/win_64_python3.14.____cp314.yaml"
+description = "List contents of ray-packages-feedstock packages built for variant win_64_python3.14.____cp314"
 
 [feature.smithy.dependencies]
 conda-smithy = "*"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -34,6 +34,10 @@ build:
 outputs:
   - package:
       name: ray-all
+    build:
+      skip:
+        # ray-rllib depends on gymnasium, which is not migrated to Python 3.14 yet.
+        - match(python, ">=3.14")
     requirements:
       host:
         - python
@@ -238,6 +242,10 @@ outputs:
               - powershell -c "Start-Sleep 15"
   - package:
       name: ray-rllib
+    build:
+      skip:
+        # gymnasium is not migrated to Python 3.14 yet.
+        - match(python, ">=3.14")
     requirements:
       host:
         - python

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -27,7 +27,7 @@ source:
     - patches/0008-bazel-disable-strict-env.patch
 
 build:
-  number: 2
+  number: 3
   skip:
     - match(python, "<3.11")
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Enable Python 3.14 builds, since it [is already support by Ray](https://github.com/ray-project/ray/issues/56434). The one exception is `ray-rllib` which currently depends on `gymnasium`, but [`gymnasium` is still blocked by `mujoco`](https://conda-forge.org/status/migration/?name=python314), therefore disable Python 3.14 packages for the `ray-rllib` subpackage only